### PR TITLE
fix: escape generated CSS values safely

### DIFF
--- a/src/font_splitter/api.py
+++ b/src/font_splitter/api.py
@@ -7,7 +7,9 @@ from os import PathLike
 from pathlib import Path
 from typing import Any
 
+import tinycss2
 from fontTools.ttLib import TTFont
+from tinycss2.serializer import serialize_string_value, serialize_url
 
 from .planner import Plan, PlannedBucket, plan_buckets
 from .ranges import compress_codepoints
@@ -311,17 +313,19 @@ def _font_face_css(
     local_names: list[str],
 ) -> str:
     sources = [
-        *(f"local('{_css_string(name)}')" for name in local_names),
-        f"url({file_name}) format('{_css_string(flavor)}')",
+        *(f"local({_css_quoted_string(name)})" for name in local_names),
+        f"url({_css_url(file_name)}) format({_css_quoted_string(flavor)})",
     ]
     lines = [
         "@font-face {",
-        f"  font-family: '{_css_string(family)}';",
-        f"  font-style: {_css_identifier(style)};",
-        f"  font-weight: {weight};",
+        f"  font-family: {_css_quoted_string(family)};",
+        f"  font-style: {_css_component_value(style, property_name='font-style')};",
+        f"  font-weight: {_css_component_value(weight, property_name='font-weight')};",
     ]
     if stretch:
-        lines.append(f"  font-stretch: {_css_identifier(stretch)};")
+        lines.append(
+            f"  font-stretch: {_css_component_value(stretch, property_name='font-stretch')};"
+        )
     lines.extend(
         [
             "  font-display: swap;",
@@ -355,9 +359,37 @@ def _split_stats(plan: Plan, *, base: str, flavor: str) -> SplitStats:
     )
 
 
-def _css_string(value: Any) -> str:
-    return str(value).replace("\\", "\\\\").replace("'", "\\'")
+def _css_quoted_string(value: Any) -> str:
+    return f'"{serialize_string_value(_css_string_value(value))}"'
 
 
-def _css_identifier(value: Any) -> str:
-    return str(value).replace(";", "").replace("{", "").replace("}", "").strip()
+def _css_url(value: Any) -> str:
+    return serialize_url(_css_string_value(value))
+
+
+def _css_string_value(value: Any) -> str:
+    return str(value).replace("\x00", "\uFFFD")
+
+
+def _css_component_value(value: Any, *, property_name: str) -> str:
+    raw_value = _css_string_value(value)
+    normalized = raw_value.replace("\r\n", " ").replace("\r", " ").replace("\n", " ")
+    if not normalized.strip():
+        raise ValueError(f"Invalid CSS value for {property_name}: {raw_value!r}")
+    tokens = tinycss2.parse_component_value_list(
+        normalized,
+        skip_comments=True,
+    )
+    serialized = tinycss2.serialize(tokens).strip()
+    if not serialized or _contains_unsafe_css_component(tokens):
+        raise ValueError(f"Invalid CSS value for {property_name}: {raw_value!r}")
+    return serialized
+
+
+def _contains_unsafe_css_component(tokens: list[Any]) -> bool:
+    for token in tokens:
+        if token.type == "error":
+            return True
+        if token.type == "literal" and token.value in {";", "{", "}"}:
+            return True
+    return False

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,6 +9,10 @@ def build_test_font() -> bytes:
     return _build_font([0x20, 0x41, 0x42, 0x43], family_name="POC Test")
 
 
+def build_test_font_with_family_name(family_name: str) -> bytes:
+    return _build_font([0x41], family_name=family_name)
+
+
 def build_multiblock_test_font() -> bytes:
     return _build_font(
         [0x20, 0x41, 0x0100, 0x2600, 0x4E00],

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,13 +2,19 @@ from io import BytesIO
 import logging
 from pathlib import Path
 
+import pytest
+import tinycss2
 from fontTools import subset
 from fontTools.ttLib import TTFont
 
 from font_splitter.api import split_font, split_font_to_memory
 from font_splitter.css_source import FontCssSource
 from font_splitter.unicode_blocks import UnicodeBlockSource
-from tests.helpers import build_multiblock_test_font, build_test_font
+from tests.helpers import (
+    build_multiblock_test_font,
+    build_test_font,
+    build_test_font_with_family_name,
+)
 
 
 def test_split_font_to_memory_defaults_to_unicode_blocks_and_auto_local_names():
@@ -16,8 +22,10 @@ def test_split_font_to_memory_defaults_to_unicode_blocks_and_auto_local_names():
 
     assert "POC-Test.Basic-Latin.woff2" in result.assets
     css_asset = result.assets["POC-Test.css"].decode("utf-8")
-    assert "local('POC Test Regular')" in css_asset
-    assert "format('woff2')" in css_asset
+    assert 'local("POC Test Regular")' in css_asset
+    assert "url(POC-Test.Basic-Latin.woff2)" in css_asset
+    assert "url(url(" not in css_asset
+    assert 'format("woff2")' in css_asset
 
 
 def test_split_font_to_memory_accepts_file_like_input():
@@ -37,11 +45,94 @@ def test_split_font_to_memory_escapes_css_strings_and_outputs_metadata():
     )
 
     css_asset = result.assets["Acme-s-Font.css"].decode("utf-8")
-    assert "font-family: 'Acme\\'s Font';" in css_asset
+    assert 'font-family: "Acme\'s Font";' in css_asset
     assert "font-style: italic;" in css_asset
     assert "font-weight: 700;" in css_asset
     assert "font-stretch: condensed;" in css_asset
-    assert "local('Acme\\'s Local')" in css_asset
+    assert 'local("Acme\'s Local")' in css_asset
+
+
+def test_split_font_to_memory_escapes_font_name_linefeeds_in_css_strings():
+    result = split_font_to_memory(
+        build_test_font_with_family_name("HanaMinA\r\n"),
+        max_codepoints=None,
+    )
+
+    css_asset = result.assets["HanaMinA.css"].decode("utf-8")
+    assert "\r" not in css_asset
+    assert "HanaMinA\n" not in css_asset
+    assert "HanaMinA\\D \\A " in css_asset
+
+    rules = tinycss2.parse_stylesheet(css_asset, skip_comments=True, skip_whitespace=True)
+    assert len(rules) == 1
+    assert rules[0].type == "at-rule"
+    declarations = tinycss2.parse_declaration_list(
+        rules[0].content,
+        skip_comments=True,
+        skip_whitespace=True,
+    )
+    assert all(declaration.type == "declaration" for declaration in declarations)
+
+
+def test_split_font_to_memory_escapes_double_quotes_in_css_strings():
+    result = split_font_to_memory(
+        build_test_font(),
+        family='Quote "Test"',
+        local_src=['Local "Name"'],
+        max_codepoints=None,
+    )
+
+    css_asset = result.assets["Quote-Test.css"].decode("utf-8")
+    assert 'font-family: "Quote \\"Test\\"";' in css_asset
+    assert 'local("Local \\"Name\\"")' in css_asset
+
+    rules = tinycss2.parse_stylesheet(css_asset, skip_comments=True, skip_whitespace=True)
+    declarations = tinycss2.parse_declaration_list(
+        rules[0].content,
+        skip_comments=True,
+        skip_whitespace=True,
+    )
+    family_declaration = next(
+        declaration
+        for declaration in declarations
+        if declaration.type == "declaration" and declaration.name == "font-family"
+    )
+    family_tokens = [
+        token for token in family_declaration.value
+        if token.type != "whitespace"
+    ]
+    assert family_tokens[0].value == 'Quote "Test"'
+
+
+def test_split_font_to_memory_preserves_multi_token_css_component_values():
+    result = split_font_to_memory(
+        build_test_font(),
+        style="oblique 10deg",
+        stretch="75%",
+        max_codepoints=None,
+    )
+
+    css_asset = result.assets["POC-Test.css"].decode("utf-8")
+    assert "font-style: oblique 10deg;" in css_asset
+    assert "font-stretch: 75%;" in css_asset
+
+
+def test_split_font_to_memory_rejects_css_declaration_breakers_in_component_values():
+    with pytest.raises(ValueError, match="Invalid CSS value for font-style"):
+        split_font_to_memory(
+            build_test_font(),
+            style="normal; src: url(evil.woff2)",
+            max_codepoints=None,
+        )
+
+
+def test_split_font_to_memory_rejects_empty_component_values():
+    with pytest.raises(ValueError, match="Invalid CSS value for font-style"):
+        split_font_to_memory(
+            build_test_font(),
+            style="   ",
+            max_codepoints=None,
+        )
 
 
 def test_split_font_to_memory_generates_css_and_woff2_assets():
@@ -113,7 +204,7 @@ def test_split_font_writes_assets_to_disk(tmp_path: Path):
     assert (tmp_path / "POC-Test.css").exists()
     TTFont(tmp_path / "POC-Test.Basic-Latin.woff")
     css = (tmp_path / "POC-Test.css").read_text(encoding="utf-8")
-    assert "local('POC Test Regular')" in css
+    assert 'local("POC Test Regular")' in css
     assert result.assets == {}
     assert result.assets_written
 


### PR DESCRIPTION
## Summary

- escape generated CSS string and URL values with tinycss2 serializers
- validate generated component CSS values before writing @font-face declarations
- add regression coverage for font names containing raw CR/LF and multi-token CSS values

Fixes #3

## Verification

- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m compileall -q src/font_splitter tests`
- `.venv/bin/python -m build`
- HanaMinA smoke: generated CSS has no raw CR/LF and parses with tinycss2
- Fusion Pixel + Noto Sans TC CSS smoke: 161 WOFF2 files generated, 161 CSS rules, no invalid WOFF2 outputs

## Risks

- Generated CSS now uses double-quoted strings instead of single-quoted strings. CSS semantics are equivalent, and tests were updated to assert the new serialization.
