### PR TITLE
ci: publish Docker from release workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,6 @@
 name: Docker
 
 on:
-  release:
-    types:
-      - published
   workflow_dispatch:
     inputs:
       release_tag:
@@ -24,7 +21,7 @@ env:
 
 jobs:
   publish:
-    name: Publish Docker Hub image
+    name: Backfill Docker Hub image
     runs-on: ubuntu-latest
 
     steps:
@@ -32,13 +29,8 @@ jobs:
         id: release
         shell: bash
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            release_tag="${{ inputs.release_tag }}"
-            publish_latest="${{ inputs.latest }}"
-          else
-            release_tag="${{ github.event.release.tag_name }}"
-            publish_latest="${{ github.event.release.prerelease == false }}"
-          fi
+          release_tag="${{ inputs.release_tag }}"
+          publish_latest="${{ inputs.latest }}"
 
           if [[ ! "$release_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             echo "Expected a release tag like v0.2.0, got: $release_tag" >&2

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,9 @@ permissions:
   issues: write
   pull-requests: write
 
+env:
+  IMAGE_NAME: vdustr/font-splitter
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -43,3 +46,52 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload "${{ steps.release.outputs.tag_name }}" dist/* --clobber
+
+      - name: Resolve Docker tags
+        id: docker-release
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        shell: bash
+        run: |
+          release_tag="${{ steps.release.outputs.tag_name }}"
+          if [[ ! "$release_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "Expected a release tag like v0.2.0, got: $release_tag" >&2
+            exit 1
+          fi
+
+          version="${release_tag#v}"
+          tags="${IMAGE_NAME}:${release_tag}"$'\n'"${IMAGE_NAME}:${version}"$'\n'"${IMAGE_NAME}:latest"
+
+          {
+            echo "version=${version}"
+            echo "tags<<EOF"
+            echo "${tags}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-qemu-action@v4
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+
+      - uses: docker/setup-buildx-action@v4
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+
+      - uses: docker/login-action@v4
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        with:
+          username: vdustr
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v7
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.docker-release.outputs.tags }}
+          labels: |
+            org.opencontainers.image.title=font-splitter
+            org.opencontainers.image.description=Python library and CLI for splitting large fonts into unicode-range WOFF/WOFF2 subsets.
+            org.opencontainers.image.source=https://github.com/VdustR/font-splitter
+            org.opencontainers.image.url=https://github.com/VdustR/font-splitter
+            org.opencontainers.image.version=${{ steps.docker-release.outputs.version }}
+            org.opencontainers.image.licenses=MIT

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ FONT_SPLITTER_FIXTURE_SHA256=<sha256> \
 ## Versioning
 
 - The package version source is `[project].version` in `pyproject.toml`.
-- Current Python rewrite target version: `0.2.0`.
+- First Python rewrite release: `v0.2.0`.
 - Last legacy npm release tag: `v0.1.5`.
 - `.release-please-manifest.json` intentionally starts at `0.1.5`; `.github/release-please-config.json` uses `bootstrap-sha` to ignore old dependency-only history before the Python rewrite.
 - After the first Release Please generated `v0.2.0` release PR has been merged, Release Please owns future version and changelog updates. Only remove or change `bootstrap-sha` in a deliberate release-maintenance change.
@@ -62,10 +62,11 @@ FONT_SPLITTER_FIXTURE_SHA256=<sha256> \
 - On push to `main`, `.github/workflows/release-please.yml` opens or updates a Release Please PR.
 - The workflow uses `RELEASE_PLEASE_TOKEN` when configured and falls back to `GITHUB_TOKEN`. Use `RELEASE_PLEASE_TOKEN` if release PR checks must run automatically from bot-created PR events.
 - The Release Please PR should update `CHANGELOG.md`, `pyproject.toml`, `.release-please-manifest.json`, and versioned README install examples.
-- Merging the Release Please PR creates the GitHub Release tag. The same workflow builds wheel and sdist artifacts and uploads them to the GitHub Release.
-- `.github/workflows/docker.yml` publishes `vdustr/font-splitter` to Docker Hub on GitHub Release publication. It requires a Docker Hub access token stored as the repo secret `DOCKERHUB_TOKEN`.
-- Docker image tags are `vX.Y.Z`, `X.Y.Z`, and `latest` for normal releases. The workflow also supports manual dispatch for backfilling an existing release tag.
-- To backfill an already-created release after Docker workflow changes, first set `DOCKERHUB_TOKEN`, then run `gh workflow run docker.yml --repo VdustR/font-splitter -f release_tag=v0.2.0 -f latest=true`.
+- Merging the Release Please PR creates the GitHub Release tag. The same workflow builds wheel and sdist artifacts, uploads them to the GitHub Release, and publishes `vdustr/font-splitter` to Docker Hub. This avoids relying on a second workflow triggered by a release created with `GITHUB_TOKEN`.
+- Docker publishing requires a Docker Hub access token stored as the repo secret `DOCKERHUB_TOKEN`.
+- Docker image tags are `vX.Y.Z`, `X.Y.Z`, and `latest` for normal releases.
+- `.github/workflows/docker.yml` is manual-only and is used to backfill or repair an existing release tag.
+- To backfill an already-created release after Docker workflow changes, first set `DOCKERHUB_TOKEN`, then run `gh workflow run docker.yml --repo VdustR/font-splitter -f release_tag=v0.2.1 -f latest=true`.
 - PyPI publishing is not configured yet. Keep the documented install path as a GitHub tag URL until PyPI Trusted Publishing is intentionally added.
 
 ## Git Safety

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ docker run --rm -v "$PWD:/fonts" vdustr/font-splitter:v0.2.1 input.ttf --output 
 ```
 <!-- x-release-please-end -->
 
-`latest` follows the latest GitHub release. Version tags are also published without the `v` prefix, such as `vdustr/font-splitter:0.2.0`.
+`latest` follows the latest GitHub release. Version tags are also published without the `v` prefix, such as `vdustr/font-splitter:0.2.1`.
 
 Docker tags before `v0.2.0` contain the legacy Node.js implementation. Use `v0.2.0` or newer for the Python package.
 
@@ -233,12 +233,12 @@ Releases are managed with Release Please on `main`.
 - Use Conventional Commit titles for merged changes. `fix:` produces a patch release, `feat:` produces a minor release, and `!` or `BREAKING CHANGE:` marks a breaking change. While the package is still `0.x`, breaking changes bump the minor version.
 - PR titles are checked against the Conventional Commits format. This keeps squash-merge commit titles compatible with Release Please.
 - Release Please opens or updates a release PR that updates `CHANGELOG.md`, `pyproject.toml`, `.release-please-manifest.json`, and versioned README install examples.
-- Merging the release PR creates the GitHub Release tag. The release workflow then builds the wheel and source distribution and uploads them as GitHub Release assets.
-- The Docker workflow publishes `vdustr/font-splitter` to Docker Hub on GitHub Release publication when `DOCKERHUB_TOKEN` is configured. It publishes `vX.Y.Z`, `X.Y.Z`, and `latest` tags.
+- Merging the release PR creates the GitHub Release tag. The release workflow then builds the wheel and source distribution, uploads them as GitHub Release assets, and publishes `vdustr/font-splitter` to Docker Hub when `DOCKERHUB_TOKEN` is configured.
+- Docker images are published as `vX.Y.Z`, `X.Y.Z`, and `latest` tags. The separate Docker workflow is manual-only and is used to backfill or repair an existing release image.
 - If Release Please PR checks must run automatically, configure `RELEASE_PLEASE_TOKEN`; otherwise the workflow falls back to GitHub's default token.
 - PyPI publishing is intentionally not configured yet. The documented install path is the GitHub tag URL.
 
-The current Python rewrite bootstraps from the last npm release, `v0.1.5`, toward `v0.2.0`.
+Release Please was bootstrapped from the last npm release, `v0.1.5`. The first Python release was `v0.2.0`.
 
 ### Test Fixture Policy
 


### PR DESCRIPTION
## Summary

- publish Docker Hub images from the Release Please workflow when a release is created
- keep the Docker workflow as a manual backfill/repair path for existing release tags
- update README and AGENTS release-flow notes to match the new behavior

## Why

GitHub does not trigger a second workflow from events created by the default `GITHUB_TOKEN`, so a GitHub Release created by Release Please does not reliably fire a separate `release: published` Docker workflow. Publishing Docker in the same release workflow keeps the normal release path deterministic.

## Verification

- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts path }' .github/workflows/*.yml`
- `git diff --check`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m compileall -q src/font_splitter tests`
- `.venv/bin/python -m build`

## Risks

- Docker publishing now shares the Release Please workflow. If Docker Hub publishing fails after a GitHub Release is created, the manual Docker workflow remains available for backfill.
- The Docker workflow no longer runs on `release: published`; this is intentional because that trigger was unreliable for releases created by `GITHUB_TOKEN`.
